### PR TITLE
Feature/support custom types

### DIFF
--- a/dev/initdb/structure.sql
+++ b/dev/initdb/structure.sql
@@ -32,7 +32,8 @@ create table posts (
   categories jsonb,
   status varchar(100),
   previous_versions jsonb DEFAULT '[]'::jsonb,
-  metadata jsonb DEFAULT '{}'::jsonb
+  metadata jsonb DEFAULT '{}'::jsonb,
+  custom_string_field varchar(255)
 );
 
 create schema alt;
@@ -71,5 +72,6 @@ create table alt.posts (
   categories jsonb,
   status varchar(100),
   previous_versions jsonb DEFAULT '[]'::jsonb,
-  metadata jsonb DEFAULT '{}'::jsonb
+  metadata jsonb DEFAULT '{}'::jsonb,
+  custom_string_field varchar(255)
 );

--- a/lib/live_admin/type.ex
+++ b/lib/live_admin/type.ex
@@ -1,0 +1,10 @@
+defmodule LiveAdmin.Type do
+  @moduledoc """
+  Defines the behavior for custom Ecto types that can be used within LiveAdmin.
+
+  Modules implementing this behavior must specify:
+  - A primitive type to be treated as
+  """
+
+  @callback render_as() :: atom()
+end

--- a/test/live_admin/components/container_test.exs
+++ b/test/live_admin/components/container_test.exs
@@ -4,6 +4,7 @@ defmodule LiveAdmin.Components.ContainerTest do
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
   import Mox
+  import Ecto.Query
 
   alias LiveAdminTest.{Post, Repo, User}
   alias LiveAdminTest.Post.Version
@@ -293,6 +294,37 @@ defmodule LiveAdmin.Components.ContainerTest do
       assert response
              |> Floki.find("a[href='/user/#{user.id}']")
              |> Enum.any?()
+    end
+  end
+
+  describe "new post with custom string field" do
+    setup %{conn: conn} do
+      {:ok, view, html} = live(conn, "/live_admin_test_post/new")
+      %{view: view, response: html}
+    end
+
+    test "includes input field for custom string type", %{response: response} do
+      assert response
+             |> Floki.find("textarea[name='params[custom_string_field]']")
+             |> Enum.any?()
+    end
+
+    test "handles form change with custom string type", %{view: view} do
+      assert view
+             |> element(".resource__form")
+             |> render_change(%{"params" => %{"custom_string_field" => "  Trimmed Value  "}})
+    end
+
+    test "creates post with trimmed custom string field on form submit", %{view: view} do
+      view
+      |> form(".resource__form", %{
+        params: %{custom_string_field: "  Test Value  ", title: "Sample Title"}
+      })
+      |> render_submit()
+
+      post = Repo.one(from(p in Post, where: p.title == "Sample Title"))
+
+      assert post.custom_string_field == "Test Value"
     end
   end
 end

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -57,6 +57,7 @@ defmodule LiveAdminTest.Post do
   schema "posts" do
     field(:title, :string)
     field(:tags, {:array, :string}, default: ["test"])
+    field(:custom_string_field, LiveAdminTest.CustomStringType)
 
     belongs_to(:user, LiveAdminTest.User, type: :binary_id)
 

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -20,6 +20,23 @@ defmodule LiveAdminTest.User do
   def failing_action(_, _), do: {:error, "failed"}
 end
 
+defmodule LiveAdminTest.CustomStringType do
+  use Ecto.Type
+  @behaviour LiveAdmin.Type
+
+  # Ecto.Type callbacks
+  def type, do: :string
+
+  def cast(value) when is_binary(value), do: {:ok, String.trim(value)}
+  def cast(_), do: :error
+
+  def load(value), do: {:ok, value}
+  def dump(value), do: {:ok, value}
+
+  # LiveAdmin.Type callbacks
+  def render_as(), do: :string
+end
+
 defmodule LiveAdminTest.PostResource do
   use LiveAdmin.Resource,
     schema: LiveAdminTest.Post,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for custom Ecto types in LiveAdmin, including schema changes, resource handling updates, and tests.
> 
>   - **Database Schema**:
>     - Add `custom_string_field` of type `varchar(255)` to `posts` and `alt.posts` in `structure.sql`.
>   - **Resource Handling**:
>     - Update `fields/2` in `resource.ex` to handle custom types using `parse_type/1` and `get_custom_type/1`.
>     - Introduce `LiveAdmin.Type` behavior in `type.ex` for custom Ecto types.
>   - **Testing**:
>     - Add tests in `container_test.exs` for handling `custom_string_field` in forms, including trimming input values.
>     - Define `LiveAdminTest.CustomStringType` in `resources.ex` to implement custom type behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jakespracher%2Flive_admin&utm_source=github&utm_medium=referral)<sup> for 969da4ed39dc0de0f211bd7e861ad88bd881f503. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->